### PR TITLE
Added new changes to prototype

### DIFF
--- a/entry.html
+++ b/entry.html
@@ -306,7 +306,7 @@
           default:
             document.getElementById("error-summary-display").className = "flash error-summary error-summary--show";
             var entry = document.createElement('li');
-            //entry.appendChild(document.createTextNode("The details you entered do not have a valid protection"));
+            entry.appendChild(document.createTextNode("The details you entered do not have a valid protection"));
             errorsummarylist.appendChild(entry);
         }
       }

--- a/entry.html
+++ b/entry.html
@@ -6,7 +6,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-  <title>PSA Lookup</title>
+  <title>Lifetime Allowance Protection Checker</title>
 
   <script type="text/javascript">
     (function() {
@@ -18,6 +18,9 @@
         d.getElementsByTagName("head")[0][c](a);
       }
     })();
+      
+      function moveOnMax(field, nextFieldID) { if (field.value.length >= field.maxLength) { nextFieldID.focus(); } }
+      
   </script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -86,10 +89,9 @@
 
         <p class="">English | Cymraeg</p>
 
-        <h1 class="heading-48 heading--underlined"> PSA Lookup form</h1>
+        <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
 
-        <p> Input a Pension scheme administrator check reference and client Lifetime Allowance reference to find out whether a pension has Lifetime Allowance protection.
-        </p>
+          <p> Enter a Scheme Administrator reference and a Protection Notification number to check the details and validity of any protection type </p>
 
         <div class="flash error-summary " id="error-summary-display" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
           <h2 id="error-summary-heading" class="h3-heading">There are errors on this page</h2>
@@ -103,34 +105,34 @@
 
               <div id="psaref" class="form-field form-field--tall">
 
-                <label> <h2 style="width: 570px"> Pension Scheme Administrator Check Reference </h2>
+                <label> <h2 style="width: 570px"> Scheme Administrator Reference </h2>
                     <div id="psareferr"></div>
                     <p class="form-field--hint">Example: PSA12345678A</p>
-                    <input type="text" name="pensionSchemeAdministratorCheckReference" id="pensionSchemeAdministratorCheckReference"
-                    class="input--medium input--cleared"  maxlength="3" style="width: 70px; float: left;"/>
-                    <input type="text" name="pensionSchemeAdministratorCheckReference2" id="pensionSchemeAdministratorCheckReference2"
-                    class="input--medium input--cleared"  maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
-                    <input type="text" name="pensionSchemeAdministratorCheckReference3" id="pensionSchemeAdministratorCheckReference3"
-                    class="input--medium input--cleared"  maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
-                    <input type="text" name="pensionSchemeAdministratorCheckReference4" id="pensionSchemeAdministratorCheckReference4"
-                    class="input--medium input--cleared"  maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
+                    <input class="uppercase" type="text" name="pensionSchemeAdministratorCheckReference" id="pensionSchemeAdministratorCheckReference1"
+                    class="input--medium input--cleared" onkeyup="moveOnMax(this,document.getElementById('pensionSchemeAdministratorCheckReference2'))"  maxlength="3" style="width: 70px; float: left;"/>
+                        <input class="uppercase" type="text" name="pensionSchemeAdministratorCheckReference2" id="pensionSchemeAdministratorCheckReference2"
+                    class="input--medium input--cleared" onkeyup="moveOnMax(this,document.getElementById('pensionSchemeAdministratorCheckReference3'))" maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
+                    <input class="uppercase" type="text" name="pensionSchemeAdministratorCheckReference3" id="pensionSchemeAdministratorCheckReference3"
+                    class="input--medium input--cleared" onkeyup="moveOnMax(this,document.getElementById('pensionSchemeAdministratorCheckReference4'))" maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
+                    <input class="uppercase" type="text" name="pensionSchemeAdministratorCheckReference4" id="pensionSchemeAdministratorCheckReference4"
+                    class="input--medium input--cleared" maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
                 </label>
 
               </div>
 
               <div id="ltaref" class="form-field">
 
-                <label> <h2> Lifetime Allowance Reference </h2>
+                <label> <h2> Protection Notification Number </h2>
                     <div id="ltareferr"></div>
                     <p class="form-field--hint">Example: IP141000000000A</p>
                     <input type="text" name="lifetimeAllowanceReference" id="lifetimeAllowanceReference"
-                    class="input--medium input--cleared" maxlength="4" style="width: 70px; float: left;"/>
+                    class="input--medium input--cleared uppercase" onkeyup="moveOnMax(this,document.getElementById('lifetimeAllowanceReference2'))" maxlength="4" style="width: 70px; float: left;"/>
                     <input type="text" name="lifetimeAllowanceReference2" id="lifetimeAllowanceReference2"
-                    class="input--medium input--cleared" maxlength="4" style="width: 70px; float: left; margin-left: 10px;"/>
+                    class="input--medium input--cleared uppercase" onkeyup="moveOnMax(this,document.getElementById('lifetimeAllowanceReference3'))" maxlength="4" style="width: 70px; float: left; margin-left: 10px;"/>
                     <input type="text" name="lifetimeAllowanceReference3" id="lifetimeAllowanceReference3"
-                    class="input--medium input--cleared" maxlength="4" style="width: 70px; float: left; margin-left: 10px;"/>
+                    class="input--medium input--cleared uppercase" onkeyup="moveOnMax(this,document.getElementById('lifetimeAllowanceReference4'))" maxlength="4" style="width: 70px; float: left; margin-left: 10px;"/>
                     <input type="text" name="lifetimeAllowanceReference4" id="lifetimeAllowanceReference4"
-                    class="input--medium input--cleared" maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
+                    class="input--medium input--cleared uppercase" maxlength="3" style="width: 70px; float: left; margin-left: 10px;"/>
                 </label>
 
               </div>
@@ -299,10 +301,12 @@
           case "PSA12345678G":
             window.location.href = "https://smudgey.github.io/result7";
             break;
+          case "PSA12345678H":
+            window.location.href = "https://smudgey.github.io/invalidResult";
           default:
             document.getElementById("error-summary-display").className = "flash error-summary error-summary--show";
             var entry = document.createElement('li');
-            entry.appendChild(document.createTextNode("The details you entered do not have a valid protection"));
+            //entry.appendChild(document.createTextNode("The details you entered do not have a valid protection"));
             errorsummarylist.appendChild(entry);
         }
       }

--- a/formtest.html
+++ b/formtest.html
@@ -5,14 +5,14 @@
   <html>
   <form id="psaform">
     <div id="psaref" class="form-field form-field--tall">
-      <label> Pension Scheme Administrator Check Reference
+      <label> Scheme Administrator Check Reference
         <div id="psareferr"></div>
                     <p class="form-field--hint">Example: PSA12345678A</p>
                     <input type="text" name="pensionSchemeAdministratorCheckReference" id="pensionSchemeAdministratorCheckReference" class="input--medium input--cleared" value="">
                 </label>
     </div>
     <div id="ltaref" class="form-field">
-      <label> Lifetime Allowance Reference
+      <label> Protection Notification Number
         <div id="ltareferr"></div>
                     <p class="form-field--hint">Example: IP141000000000A</p>
                     <input type="text" name="lifetimeAllowanceReference" id="lifetimeAllowanceReference" class="input--medium input--cleared" value="">

--- a/index.html
+++ b/index.html
@@ -65,7 +65,6 @@ if (empty($_POST["lifetimeAllowanceReference"])) {
     <?php endif; ?>
     <input type="submit" name="submit" value="Submit">
   </form>
+ </body>
 
   </html>
-
- </body>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ if (empty($_POST["lifetimeAllowanceReference"])) {
   <form method="post" action="<?php echo htmlspecialchars($_SERVER[" PHP_SELF "]);?>">
     <?php if($psaRefErr!=='') : ?>
     <div class="form-field form-field--error fields-aligned form-field--tall">
-      <label> Pension Scheme Administrator Check Reference
+      <label> Scheme administrator reference
                         <div class="error-notification" id="PSA Ref must be entered">
                         <?php echo $psaRefErr ?>
                         </div>
@@ -36,7 +36,7 @@ if (empty($_POST["lifetimeAllowanceReference"])) {
     </div>
     <?php else : ?>
     <div class="form-field form-field--tall">
-      <label> Pension Scheme Administrator Check Reference
+      <label> Scheme administrator reference
                     <p class="form-field--hint">Example: PSA12345678A</p>
                     <input type="text" name="pensionSchemeAdministratorCheckReference" id="pensionSchemeAdministratorCheckReference" class="input--medium input--cleared" value="">
                 </label>
@@ -65,6 +65,7 @@ if (empty($_POST["lifetimeAllowanceReference"])) {
     <?php endif; ?>
     <input type="submit" name="submit" value="Submit">
   </form>
-  </body>
 
   </html>
+
+ </body>

--- a/invalidResult.html
+++ b/invalidResult.html
@@ -115,28 +115,20 @@
 
         <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
         <br>
-          <h2> Results  </h2>
+          <h2>Results</h2>
         <table>
           <tbody>
             <tr>
               <td class="font-small">PSA Reference:</td>
-              <td class="font-small">PSA12345678B</td>
+              <td class="font-small">PSA12345678H</td>
             </tr>
             <tr>
               <td class="font-small">LTA Reference:</td>
-              <td class="font-small">IP141000000000B</td>
-            </tr>
-            <tr>
-              <td class="font-small">Protection Type:</td>
-              <td class="font-small">INDIVIDUAL PROTECTION 2014</td>
-            </tr>
-            <tr>
-              <td class="font-small">Protected Amount:</td>
-              <td class="font-small">£1,500,000</td>
+              <td class="font-small">IP141000000000H</td>
             </tr>
             <tr>
               <td class="font-small">Status:</td>
-              <td class="font-small">VALID</td>
+              <td class="font-small">INVALID</td>
             </tr>
           </tbody>
         </table>

--- a/public/application.css
+++ b/public/application.css
@@ -22594,3 +22594,7 @@ abbr[title], acronym[title] {
         line-height: 1.25
     }
 }
+
+input.uppercase {
+    text-transform: uppercase;
+}

--- a/result1.html
+++ b/result1.html
@@ -113,8 +113,9 @@
       <article class="content__body">
         <p class="">English | Cymraeg</p>
 
-        <h1 class="heading-48 heading--underlined"> PSA Lookup Results</h1>
+        <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
         <br>
+          <h2> Results  </h2>
         <table>
           <tbody>
             <tr>
@@ -129,8 +130,15 @@
               <td class="font-small">Protection Type:</td>
               <td class="font-small">FIXED PROTECTION 2016</td>
             </tr>
+            <tr>
+              <td class="font-small">Status:</td>
+              <td class="font-small">VALID</td>
+            </tr>
           </tbody>
         </table>
+          <br>
+          <input class="button" type="submit" name="print" value="Print" onclick="">
+          <br>
         <br>
         <a class="back-link" href="/entry">Back</a>
 

--- a/result3.html
+++ b/result3.html
@@ -113,8 +113,9 @@
       <article class="content__body">
         <p class="">English | Cymraeg</p>
 
-        <h1 class="heading-48 heading--underlined"> PSA Lookup Results</h1>
+        <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
         <br>
+          <h2> Results  </h2>
         <table>
           <tbody>
             <tr>
@@ -131,10 +132,17 @@
             </tr>
             <tr>
               <td class="font-small">Protected Amount:</td>
-              <td class="font-small">£25,000</td>
+              <td class="font-small">£1,250,000</td>
+            </tr>
+            <tr>
+              <td class="font-small">Status:</td>
+              <td class="font-small">VALID</td>
             </tr>
           </tbody>
         </table>
+        <br>
+          <input class="button" type="submit" name="print" value="Print" onclick="">
+          <br>
         <br>
         <a class="back-link" href="/entry">Back</a>
 

--- a/result4.html
+++ b/result4.html
@@ -113,8 +113,9 @@
       <article class="content__body">
         <p class="">English | Cymraeg</p>
 
-        <h1 class="heading-48 heading--underlined"> PSA Lookup Results</h1>
+        <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
         <br>
+          <h2>Results</h2>
         <table>
           <tbody>
             <tr>
@@ -130,11 +131,22 @@
               <td class="font-small">PRIMARY PROTECTION</td>
             </tr>
             <tr>
+              <td class="font-small">Primary Protection Factor:</td>
+              <td class="font-small">0.467</td>
+            </tr>
+            <tr>
               <td class="font-small">Protected Amount:</td>
-              <td class="font-small">£250,000</td>
+              <td class="font-small">£2,500,000</td>
+            </tr>
+            <tr>
+              <td class="font-small">Status:</td>
+              <td class="font-small">VALID</td>
             </tr>
           </tbody>
         </table>
+        <br>
+          <input class="button" type="submit" name="print" value="Print" onclick="">
+          <br>
         <br>
         <a class="back-link" href="/entry">Back</a>
 

--- a/result5.html
+++ b/result5.html
@@ -113,8 +113,9 @@
       <article class="content__body">
         <p class="">English | Cymraeg</p>
 
-        <h1 class="heading-48 heading--underlined"> PSA Lookup Results</h1>
+        <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
         <br>
+          <h2>Results</h2>
         <table>
           <tbody>
             <tr>
@@ -131,10 +132,17 @@
             </tr>
             <tr>
               <td class="font-small">Protected Amount:</td>
-              <td class="font-small">£999,999</td>
+              <td class="font-small">75%</td>
+            </tr>
+            <tr>
+              <td class="font-small">Status:</td>
+              <td class="font-small">VALID</td>
             </tr>
           </tbody>
         </table>
+        <br>
+          <input class="button" type="submit" name="print" value="Print" onclick="">
+          <br>
         <br>
         <a class="back-link" href="/entry">Back</a>
 

--- a/result6.html
+++ b/result6.html
@@ -113,8 +113,9 @@
       <article class="content__body">
         <p class="">English | Cymraeg</p>
 
-        <h1 class="heading-48 heading--underlined"> PSA Lookup Results</h1>
+        <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
         <br>
+          <h2>Results</h2>
         <table>
           <tbody>
             <tr>
@@ -129,8 +130,15 @@
               <td class="font-small">Protection Type:</td>
               <td class="font-small">FIXED PROTECTION</td>
             </tr>
+            <tr>
+              <td class="font-small">Status:</td>
+              <td class="font-small">VALID</td>
+            </tr>
           </tbody>
         </table>
+        <br>
+          <input class="button" type="submit" name="print" value="Print" onclick="">
+          <br>
         <br>
         <a class="back-link" href="/entry">Back</a>
 

--- a/result7.html
+++ b/result7.html
@@ -113,8 +113,9 @@
       <article class="content__body">
         <p class="">English | Cymraeg</p>
 
-        <h1 class="heading-48 heading--underlined"> PSA Lookup Results</h1>
+        <h1 class="heading-48 heading--underlined"> Lifetime Allowance Protection Checker</h1>
         <br>
+          <h2>Results</h2>
         <table>
           <tbody>
             <tr>
@@ -129,8 +130,15 @@
               <td class="font-small">Protection Type:</td>
               <td class="font-small">FIXED PROTECTION 2014</td>
             </tr>
+            <tr>
+              <td class="font-small">Status:</td>
+              <td class="font-small">VALID</td>
+            </tr>
           </tbody>
         </table>
+        <br>
+          <input class="button" type="submit" name="print" value="Print" onclick="">
+          <br>
         <br>
         <a class="back-link" href="/entry">Back</a>
 

--- a/start.html
+++ b/start.html
@@ -4,7 +4,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
-    <title>Tax on your private pension contributions: Lifetime allowance - GOV.UK</title>
+    <title>Pension administrators: check your member's protection status - GOV.UK</title>
 
     <script type="text/javascript">
         (function() {
@@ -26,364 +26,419 @@
 </head>
 
 <body>
-    <script>
-        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+<script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+</script>
 
-    <div id="skiplink-container">
-        <div>
-            <a href="#content" class="skiplink">Skip to main content</a>
-        </div>
+<div id="skiplink-container">
+    <div>
+        <a href="#content" class="skiplink">Skip to main content</a>
     </div>
+</div>
 
-    <div id="global-cookie-message">
-        <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-    </div>
+<div id="global-cookie-message">
+    <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+</div>
 
-    <header role="banner" id="global-header" class="">
-        <div class="header-wrapper">
-            <div class="header-global">
-                <div class="header-logo">
-                    <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" id="logo" class="content">
-                        <img src="/public/images/gov.uk_logotype_crown.png" width="36" height="32" alt=""> GOV.UK
-                    </a>
-                </div>
-                <a href="#search" class="search-toggle js-header-toggle">Search</a>
-
-                <form id="search" class="site-search" action="/search" method="get" role="search">
-                    <div class="content">
-                        <label for="site-search-text">Search</label>
-                        <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
-                        <input class="submit" type="submit" value="Search">
-                    </div>
-                </form>
-
+<header role="banner" id="global-header" class=" with-proposition">
+    <div class="header-wrapper">
+        <div class="header-global">
+            <div class="header-logo">
+                <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" id="logo" class="content">
+                    <img src="https://assets.publishing.service.gov.uk/static/gov.uk_logotype_crown_invert_trans-203e1db49d3eff430d7dc450ce723c1002542fe1d2bce661b6d8571f14c1043c.png" width="36" height="32" alt=""> GOV.UK
+                </a>
             </div>
+            <a href="#search" class="search-toggle js-header-toggle">Search</a>
+
+            <form id="search" class="site-search" action="/search" method="get" role="search">
+                <div class="content">
+                    <label for="site-search-text">Search</label>
+                    <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
+                    <input class="submit" type="submit" value="Search">
+                </div>
+            </form>
 
         </div>
-    </header>
 
-    <div id="user-satisfaction-survey-container"></div>
-    <div id="global-header-bar"></div>
-    <div id="wrapper" class="direction-ltr">
-        <main role="main" id="content" class="guide" lang="en">
-            <div class="govuk-breadcrumbs " data-module="track-click">
-                <ol>
-                    <li class="">
-                        <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/" data-track-options='{"dimension28":"3","dimension29":"Home"}' class="" aria-current="false" href="/">Home</a>
-                    </li>
-                    <li class="">
-                        <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="/browse/tax" data-track-options='{"dimension28":"3","dimension29":"Money and tax"}' class="" aria-current="false" href="/browse/tax">Money and tax</a>
-                    </li>
-                    <li class="">
-                        <a data-track-category="breadcrumbClicked" data-track-action="3" data-track-label="/browse/tax/income-tax" data-track-options='{"dimension28":"3","dimension29":"Income Tax"}' class="" aria-current="false" href="/browse/tax/income-tax">Income Tax</a>
-                    </li>
-                </ol>
-            </div>
-
-            <div class="grid-row">
-                <div class="column-two-thirds">
-                    <div class="govuk-title length-average">
-                        <h1>Tax on your private pension contributions</h1>
-                    </div>
-
-                    <aside class="part-navigation-container" role="complementary">
-                        <nav role="navigation" class="grid-row part-navigation" aria-label="Pages in this guide">
-                            <ol class="column-half">
-                                <li>
-                                    <a href="/tax-on-your-private-pension/overview">Overview</a>
-                                </li>
-                                <li>
-                                    <a href="/tax-on-your-private-pension/pension-tax-relief">Tax relief</a>
-                                </li>
-                            </ol>
-                            <ol class="column-half" start="3">
-                                <li>
-                                    <a href="/tax-on-your-private-pension/annual-allowance">Annual allowance</a>
-                                </li>
-                                <li>
-                                    Lifetime allowance
-                                </li>
-                            </ol>
-                        </nav>
-
-                    </aside>
-
-                    <h1 class="part-title">
-          4. Lifetime allowance
-        </h1>
-                    <div class="govuk-govspeak direction-ltr disable-youtube">
-                        <p>You usually pay tax if your pension pots are worth more than the lifetime allowance. This is currently £1 million.</p>
-
-                        <p>You might be able to protect your pension pot from reductions to the lifetime allowance.</p>
-
-                        <h2 id="check-how-much-lifetime-allowance-youve-used">Check how much lifetime allowance you’ve used</h2>
-
-                        <p>Ask your pension provider how much of your lifetime allowance you’ve used.</p>
-
-                        <p>If you’re in more than one pension scheme, you must add up what you’ve used in all pension schemes you belong to.</p>
-
-                        <p>What counts towards your allowance depends on the type of pension pot you get.</p>
-
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Type of pension pot</th>
-                                    <th>What counts towards your lifetime allowance</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <a href="/pension-types">Defined contribution</a> - personal, stakeholder and most workplace schemes</td>
-                                    <td>Money in pension pots that goes towards paying you, however you decide to <a href="/personal-pensions-your-rights/how-your-pension-is-paid">take the money</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <a href="/pension-types">Defined benefit</a> - some workplace schemes</td>
-                                    <td>Usually 20 times the pension you get in the first year plus your lump sum - check with your pension provider</td>
-                                </tr>
-                            </tbody>
-                        </table>
-
-                        <p>Your pension provider may ask for information about other pension schemes you’re in so they can check if you’re above your lifetime allowance when you:</p>
-
-                        <ul>
-                            <li>decide to take money from a pension pot</li>
-                            <li>turn 75</li>
-                            <li>transfer your pension overseas</li>
-                        </ul>
-
-                        <h2 id="pay-tax-if-you-go-above-your-lifetime-allowance">Pay tax if you go above your lifetime allowance</h2>
-
-                        <p>You’ll get a statement from your pension provider telling you how much tax you owe if you go above your lifetime allowance. Your pension provider will deduct the tax before you start getting your pension.</p>
-
-                        <p>You’ll need to report the tax deducted by filling in a <a href="/self-assessment-tax-returns">Self Assessment tax return</a> - download and fill in <a href="/government/publications/self-assessment-additional-information-sa101">form SA101</a>                            if you’re using paper forms. You’ll get information from your pension provider to help you do this.</p>
-
-                        <div role="note" aria-label="Information" class="application-notice info-notice">
-                            <p><a href="/tax-on-pension-death-benefits">If you die before taking your pension</a> HM Revenue and Customs (<abbr title="HM Revenue and Customs">HMRC</abbr>) will bill the person who inherits your pension for the tax.</p>
-                        </div>
-
-                        <h3 id="rates">Rates</h3>
-                        <p>The rate of tax you pay on pension savings above your lifetime allowance depends on how the money is paid to you - the rate is:</p>
-
-                        <ul>
-                            <li>55% if you get it as a lump sum</li>
-                            <li>25% if you get it any other way, for example pension payments or cash withdrawals</li>
-                        </ul>
-
-                        <h2 id="protect-your-lifetime-allowance">Protect your lifetime allowance</h2>
-
-                        <p>The lifetime allowance was reduced in April 2016. You can <a href="/guidance/pension-schemes-protect-your-lifetime-allowance">apply to protect your lifetime allowance</a> from this reduction.</p>
-
-                        <p>Tell your pension provider the type of protection and the protection reference number when you decide to take money from your pension pot.</p>
-
-                        <h3 id="withdrawing-cash-from-a-pension-pot">Withdrawing cash from a pension pot</h3>
-
-                        <p>You can’t <a href="/personal-pensions-your-rights/how-your-pension-is-paid">withdraw cash from a defined contribution pension pot</a> (‘uncrystallised funds pension lump sums’) if you have:</p>
-
-                        <ul>
-                            <li>primary or enhanced protection covering a lump sum worth more than £375,000</li>
-                            <li>‘lifetime allowance enhancement factor’ if your unused lifetime allowance is less than 25% of the cash you want to withdraw</li>
-                        </ul>
-
-                        <h3 id="reporting-changes-to-hmrc">Reporting changes to <abbr title="HM Revenue and Customs">HMRC</abbr>
-</h3>
-
-                        <p>You can lose enhanced protection or any type of fixed protection if:
-                        </p>
-
-                        <ul>
-                            <li>you make new savings in a pension scheme</li>
-                            <li>you are enrolled in a new workplace pension scheme</li>
-                            <li>you transfer money between pension schemes in a way that doesn’t meet the transfer rules</li>
-                            <li>you’ve got enhanced protection and, when you take your pension benefits, their value has increased more than the amount allowed in the enhanced protection tax rules - this is called ‘relevant benefit accrual’</li>
-                            <li>you’ve got fixed protection and the value of your pension pot in any tax year grows at a higher rate than is allowed by the tax rules - this is called ‘benefit accrual’</li>
-                        </ul>
-
-                        <p>You can <a href="/guidance/pension-schemes-protect-your-lifetime-allowance#report-a-change">report changes online or by post</a>.</p>
-
-                        <p>Ask your employer whether they’re likely to enrol you in a workplace pension. To make sure you don’t lose protection, you can either:</p>
-
-                        <ul>
-                            <li>
-                                <a href="/workplace-pensions/if-you-want-to-leave-your-workplace-pension-scheme">opt out</a> of most schemes within a month</li>
-                            <li>ask not to be enrolled in some schemes - your employer may need evidence of your lifetime allowance protection</li>
-                        </ul>
-
-                        <p><a href="/government/organisations/hm-revenue-customs/contact/pension-scheme-enquiries">Tell <abbr title="HM Revenue and Customs">HMRC</abbr></a> if you think you might have lost your protection.</p>
-
-                        <h2 id="pension-administrator-scheme-lookup">Pension Administrator Scheme Lookup</h2>
-
-                        <p>There are various protection schemes currently in place. Pension scheme administators can <a href="https://smudgey.github.io/entry">lookup and verify current protections</a>  online.</p>
-
-                        <h2 id="if-you-have-the-right-to-take-your-pension-before-50">If you have the right to take your pension before 50</h2>
-
-                        <p>You may have a <a href="/hmrc-internal-manuals/pensions-tax-manual/ptm082000">reduced lifetime allowance</a> if you have the right to take your pension before you’re 50 under a pension scheme you joined before 2006.</p>
-
-                        <p>This only applies to people in <a href="/hmrc-internal-manuals/pensions-tax-manual/ptm062220#IDAGQPPG">certain jobs</a> (for example professional sports, dance and modelling) who start taking their pension before they’re 55.</p>
-
-                        <p>Your lifetime allowance isn’t reduced if you’re in a <a href="/hmrc-internal-manuals/pensions-tax-manual/ptm062220#IDATUPPG">pension scheme for uniformed services</a>, for example the armed forces, police and fire services.</p>
-
-
-                    </div>
-
-
-                    <nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
-                        <ul class="group">
-                            <li class="previous-page">
-                                <a href="/tax-on-your-private-pension/annual-allowance" rel="prev">
-                                    <span class="pagination-part-title">Previous</span>
-                                    <span class="pagination-label">Annual allowance</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
-
-
-                    <div class="print-link">
-                        <a rel="alternate" href="/tax-on-your-private-pension/print">Print entire guide</a>
-                    </div>
-                </div>
-                <div class="column-third add-title-margin">
-
-
-                    <aside class="govuk-related-items" data-module="track-click" role="complementary">
-                        <h2>
-        Money and tax
-      </h2>
-
-
-                        <nav role="navigation">
-                            <ul>
-                                <li>
-                                    <a data-track-category="relatedLinkClicked" data-track-action="1.1" data-track-label="/difficulties-paying-hmrc" data-track-options="{&quot;dimension28&quot;:&quot;3&quot;,&quot;dimension29&quot;:&quot;If you can't pay your tax bill on time&quot;}" href="/difficulties-paying-hmrc">If you can't pay your tax bill on time</a>
-                                </li>
-                                <li>
-                                    <a data-track-category="relatedLinkClicked" data-track-action="1.2" data-track-label="/if-you-dont-pay-your-tax-bill" data-track-options="{&quot;dimension28&quot;:&quot;3&quot;,&quot;dimension29&quot;:&quot;If you don't pay your tax bill&quot;}" href="/if-you-dont-pay-your-tax-bill">If you don't pay your tax bill</a>
-                                </li>
-                                <li class="related-items-more">
-                                    <a data-track-category="relatedLinkClicked" data-track-action="1.3" data-track-label="/browse/tax" data-track-options='{"dimension28":"3","dimension29":"More"}' href="/browse/tax">More
-                                      <span class="visuallyhidden">in Money and tax</span></a> </li>
-                            </ul>
-                        </nav>
-                        <h2>Elsewhere on GOV.UK</h2>
-                        <nav role="navigation">
-                            <ul>
-                                <li>
-                                    <a href="/plan-retirement-income">Plan your retirement income</a>
-                                </li>
-                                <li>
-                                    <a href="/pension-types">Types of private pensions</a>
-                                </li>
-                                <li>
-                                  <a href="/entry">Pension scheme administator lookup</a>
-                                </li>
-                            </ul>
-                        </nav>
-                        <h2>Elsewhere on the web</h2>
-
-
-                        <nav role="navigation">
-                            <ul>
-                                <li>
-                                    <a data-track-category="relatedLinkClicked" data-track-action="3.1" data-track-label="https://www.tax.service.gov.uk/paac" data-track-options='{"dimension28":"1","dimension29":"Annual allowance calculator"}' rel="external" href="https://www.tax.service.gov.uk/paac">Annual allowance calculator</a>
-                                </li>
-                            </ul>
-                        </nav>
-                    </aside>
-
-
-
-
-
-                </div>
-
-            </div>
-
-        </main>
-    </div>
-
-
-    <footer class="group js-footer" id="footer" role="contentinfo">
-
-        <div class="footer-wrapper">
-            <div class="footer-categories">
-                <div class="footer-explore">
-                    <h2>Services and information</h2>
-
-                    <ul>
-                        <li><a href="/browse/benefits">Benefits</a></li>
-                        <li><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></li>
-                        <li><a href="/browse/business">Business and self-employed</a></li>
-                        <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
-                        <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
-                        <li><a href="/browse/justice">Crime, justice and the law</a></li>
-                        <li><a href="/browse/disabilities">Disabled people</a></li>
-                        <li><a href="/browse/driving">Driving and transport</a></li>
-                    </ul>
-                    <ul>
-                        <li><a href="/browse/education">Education and learning</a></li>
-                        <li><a href="/browse/employing-people">Employing people</a></li>
-                        <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
-                        <li><a href="/browse/housing-local-services">Housing and local services</a></li>
-                        <li><a href="/browse/tax">Money and tax</a></li>
-                        <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
-                        <li><a href="/browse/visas-immigration">Visas and immigration</a></li>
-                        <li><a href="/browse/working">Working, jobs and pensions</a></li>
-                    </ul>
-                </div>
-
-                <div class="footer-inside-government">
-                    <h2>Departments and policy</h2>
-
-                    <ul>
-                        <li><a href="/government/how-government-works">How government works</a></li>
-                        <li><a href="/government/organisations">Departments</a></li>
-                        <li><a href="/government/world">Worldwide</a></li>
-                        <li><a href="/government/policies">Policies</a></li>
-                        <li><a href="/government/publications">Publications</a></li>
-                        <li><a href="/government/announcements">Announcements</a></li>
-                    </ul>
-                </div>
-                <hr>
-            </div>
-
-
-            <div class="footer-meta">
-                <div class="footer-meta-inner">
-                    <h2 class="visuallyhidden">Support links</h2>
-                    <ul>
-                        <li><a href="/help">Help</a></li>
-                        <li><a href="/help/cookies">Cookies</a></li>
-                        <li><a href="/contact">Contact</a></li>
-                        <li><a href="/help/terms-conditions">Terms and conditions</a></li>
-                        <li><a href="/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a></li>
-                        <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+        <div class="header-proposition">
+            <div class="content">
+                <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+                <nav id="proposition-menu" class="no-proposition-name">
+                    <ul id="proposition-links">
+                        <li>
+                            <a class="" href="/government/organisations">
+                                Departments
+                            </a>
+                        </li>
+                        <li>
+                            <a class="" href="/government/world">
+                                Worldwide
+                            </a>
+                        </li>
+                        <li>
+                            <a class="" href="/government/how-government-works">
+                                How government works
+                            </a>
+                        </li>
+                        <li>
+                            <a class="" href="/government/get-involved">
+                                Get involved
+                            </a>
+                        </li>
+                        <li class="clear-child">
+                            <a class="" href="/government/policies">
+                                Policies
+                            </a>
+                        </li>
+                        <li>
+                            <a class="" href="/government/publications">
+                                Publications
+                            </a>
+                        </li>
+                        <li>
+                            <a class="" href="/government/publications?publication_filter_option=consultations">
+                                Consultations
+                            </a>
+                        </li>
+                        <li>
+                            <a class="" href="/government/statistics">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a class="" href="/government/announcements">
+                                Announcements
+                            </a>
                         </li>
                     </ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+</header>
+
+<div id="user-satisfaction-survey-container"></div>
+
+
+<div id="global-header-bar"></div>
+
+<div id="wrapper" class="direction-ltr">
+    <main role="main" id="content" class="detailed-guide" lang="en">
 
 
 
-                    <div class="open-government-licence">
-                        <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
-                        <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+        <div class="govuk-breadcrumbs " data-module="track-click">
+            <ol>
+
+                <li class="">
+                    <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/" data-track-options='{"dimension28":"3","dimension29":"Home"}' class="" aria-current="false" href="/">Home</a>
+                </li>
+
+                <li class="">
+                    <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="/topic/business-tax" data-track-options='{"dimension28":"3","dimension29":"Business tax"}' class="" aria-current="false" href="/topic/business-tax">Business tax</a>
+                </li>
+
+                <li class="">
+                    <a data-track-category="breadcrumbClicked" data-track-action="3" data-track-label="/topic/business-tax/pension-scheme-administration" data-track-options='{"dimension28":"3","dimension29":"Pension scheme administration"}' class="" aria-current="false" href="/topic/business-tax/pension-scheme-administration">Pension scheme administration</a>
+                </li>
+            </ol>
+        </div>
+
+
+
+
+
+        <div class="grid-row">
+            <div class="column-two-thirds">
+                <div class="govuk-title length-long">
+                    <p class="context">Guidance</p>
+                    <h1>Pension administrators: check your member's protection status</h1>
+                </div>
+
+            </div>
+            <div class="column-third">
+
+            </div>
+        </div>
+
+
+
+        <div class="grid-row">
+            <div class="column-two-thirds">
+                <div class="govuk-metadata direction-ltr" data-module="toggle">
+                    <dl>
+                        <dt>From:</dt>
+                        <dd>
+                            <a href="/government/organisations/hm-revenue-customs">HM Revenue &amp; Customs</a>
+
+                        </dd>
+                        <dt>Part of:</dt>
+                        <dd>
+                            <a href="/government/collections/pension-administrators">Pension administrators</a> and <a href="/topic/business-tax/pension-scheme-administration">Pension scheme administration</a>
+
+                        </dd>
+                        <dt>Published:</dt>
+                        <dd>6 April 2016</dd>
+                        <dt>Last updated:</dt>
+                        <dd>
+                            6 April 2017,
+                            <a href="#history" data-module="track-click" data-track-category="content-history" data-track-action="see-all-updates-link-clicked" data-track-label="history">
+                                see all updates
+                            </a>
+                        </dd>
+                    </dl>
+                </div>
+
+            </div>
+        </div>
+
+
+        <p class="description">
+            What you need to do if your members protect their pension from the lifetime allowance reduction.
+        </p>
+
+
+        <div class="grid-row sidebar-with-body" data-module="sticky-element-container" id="contents">
+            <div class="column-third">
+                <nav role="navigation">
+                    <h2>Contents</h2>
+                    <ol class="dash-list" data-module="track-click">
+                        <li>
+                            <a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="overview" href="#overview">Overview</a>
+                        </li>
+                        <li>
+                            <a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="lifetime-allowance-protection-checker" href="#Lifetime Allowance Protection Checker">Lifetime Allowance Protection Checker</a>
+                        </li>
+                        <li>
+                            <a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="protection-before-2016-reduction" href="#protection-before-2016-reduction">Protection before 2016 reduction</a>
+                        </li>
+                        <li>
+                            <a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="protection-from-2016-reduction" href="#protection-from-2016-reduction">Protection from 2016 reduction</a>
+                        </li>
+                    </ol>
+                </nav>
+
+            </div>
+            <div class="column-two-thirds ">
+
+                <div class="govuk-govspeak direction-ltr">
+                    <div class="govspeak">
+                        <h2 id="overview">Overview</h2>
+
+                        <p>Your pension members may be able to apply for protection from the reduction in the <a href="https://www.gov.uk/tax-on-your-private-pension/lifetime-allowance">lifetime allowance</a>.</p>
+
+                        <p>If there’s a <a href="https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual/ptm088100">benefit crystallisation event</a> you’ll need to send HM Revenue and Customs (<abbr title="HM Revenue and Customs">HMRC</abbr>) the <a href="https://www.gov.uk/guidance/pension-administrators-reporting-to-hmrc#event-reports">Event Report</a> if both the following apply:</p>
+
+                        <ul>
+                            <li>your member’s total benefits are more than the lifetime allowance</li>
+                            <li>they have enhanced protection, fixed protection, fixed protection 2014 or individual protection 2014</li>
+                        </ul>
+
+                        <div class="call-to-action">
+                            <p>If you need to report reference numbers for members using fixed protection 2016 and individual protection 2016, you should <a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/pension-scheme-enquiries">contact <abbr title="HM Revenue and Customs">HMRC</abbr></a>.</p>
+                        </div>
+
+                        <p>You’ll also need to make sure you <a href="https://www.gov.uk/guidance/pension-administrators-annual-and-lifetime-allowance-statements#lifetime-allowance-statement">give the right information to your members</a>.</p>
+
+                        <h2 id="lifetime-allowance-protection-checker">Lifetime Allowance Protection Checker</h2>
+
+                        <p>To check the details and status of a certificate you can use the <a href="https://smudgey.github.io/entry.html">lifetime allowance protection checker</a>. You will need the following information:</p>
+                        <ul>
+                            <li>Scheme Administrator Reference</li>
+                            <li>Protection Notification Number</li>
+                        </ul>
+                        <p>Both of these references can be located on the certificate itself. The format of these can be seen below.</p>
+
+                        <h2 id="protection-before-2016-reduction">Protection before 2016 reduction</h2>
+
+                        <p>Before 2016 your members could hold one of the following protections:</p>
+
+                        <ul>
+                            <li>enhanced protection</li>
+                            <li>primary protection</li>
+                            <li>fixed protection</li>
+                            <li>individual protection 2014</li>
+                            <li>fixed protection 2014</li>
+                        </ul>
+
+                        <p>Your members should give you the reference number for their protection and you’ll need to use this when testing their benefits.</p>
+
+                        <p>Your members can find their reference number on their protection certificate or confirmation letter. Additionally, most members will be able to view it online using the <a href="https://www.gov.uk/guidance/pension-schemes-protect-your-lifetime-allowance">protect your lifetime allowance</a> service.</p>
+
+                        <p>You may decide to ask your member for a copy of their protection certificate so you can:</p>
+
+                        <ul>
+                            <li>confirm the value of their protected pension rights</li>
+                            <li>tell the member what percentage of the lifetime allowance they’ve used up</li>
+                        </ul>
+
+                        <h2 id="protection-from-2016-reduction">Protection from 2016 reduction</h2>
+
+                        <p>Your members will need to apply for a permanent protection reference number online.</p>
+
+                        <p>The permanent reference number is in the format:</p>
+
+                        <ul>
+                            <li>FP16 followed by 10 digits and 1 letter, for fixed protection 2016 (for example FP161234567890A)</li>
+                            <li>IP16 followed by 10 digits and 1 letter, for individual protection 2016 (for example IP161234567890B)</li>
+                        </ul>
+
+                        <p>Temporary reference numbers are no longer valid. If your member has one they’ll need to apply for a permanent reference number. The temporary reference number will be in the format:</p>
+
+                        <ul>
+                            <li>AJ followed by 4 digits, for fixed protection (for example AJ1234)</li>
+                            <li>4 digits followed by AJ, for individual protection (for example 1234AJ)</li>
+                        </ul>
+
                     </div>
                 </div>
 
-                <div class="copyright">
-                    <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
-                </div>
+            </div>
+            <div data-sticky-element class="sticky-element">
+                <a class="back-to-content" data-track-category="contentsClicked" data-track-action="backToContentsLinkClicked" data-track-label="contents" data-module="track-click" href="#contents">Contents</a>
+
             </div>
         </div>
-    </footer>
 
-    <div id="global-app-error" class="app-error hidden"></div>
 
-    <script>
-        if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');
-    </script>
+        <div class="govuk-document-footer direction-ltr">
+            <h2 class="visuallyhidden">
+                Document information
+            </h2>
+            <div class="history-information" id="history">
+                <p>
+                    Published:
+                    <span class="published definition">6 April 2016</span>
+                </p>
+                <p>
+                    Updated:
+                    <span class="updated definition">6 April 2017</span>
+                </p>
+                <div class="change-notes" data-module="toggle">
+                    <p>
+                        <a href="#full-history" data-controls="full-history" data-expanded="false" data-module="track-click" data-track-category="content-history" data-track-action="full-page-history-toggled" data-track-label="full-history">
+                            + full page history
+                        </a>
+                    </p>
+                    <div class="js-hidden" id="full-history">
+                        <span class="arrow"></span>
+                        <ol>
+                            <li>
+                                <time datetime="2017-04-06T00:15:37.000+01:00" class="timestamp">6 April 2017</time>
+                                Amendments made to reflect that members applying for individual protection 2016 now need to apply for a permanent protection reference number online.
+                            </li>
+                            <li>
+                                <time datetime="2016-07-28T09:34:02.000+01:00" class="timestamp">28 July 2016</time>
+                                This guidance has been updated to reflect the new online service for members to protect their lifetime allowance from the 2014 and 2016 reduction.
+                            </li>
+                            <li>
+                                <time datetime="2016-04-06T00:15:00.000+01:00" class="timestamp">6 April 2016</time>
+                                First published.
+                            </li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+            <div class="related-information">
+                <p>From: <span class="from">
+          <span class="definition">
+            <a href="/government/organisations/hm-revenue-customs">HM Revenue &amp; Customs</a>
+          </span>
+      </span></p>
+                <p>
+                    Part of:
+                    <span class="part-of">
+        <span class="definition">
+          <a href="/government/collections/pension-administrators">Pension administrators</a>
+        </span>
+        <span class="definition">
+          <a href="/topic/business-tax/pension-scheme-administration">Pension scheme administration</a>
+        </span>
+      </span></p>
+            </div>
+        </div>
+
+    </main>
+</div>
+
+<footer class="group js-footer" id="footer" role="contentinfo">
+
+    <div class="footer-wrapper">
+        <div class="footer-categories">
+            <div class="footer-explore">
+                <h2>Services and information</h2>
+
+                <ul>
+                    <li><a href="/browse/benefits">Benefits</a></li>
+                    <li><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></li>
+                    <li><a href="/browse/business">Business and self-employed</a></li>
+                    <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
+                    <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
+                    <li><a href="/browse/justice">Crime, justice and the law</a></li>
+                    <li><a href="/browse/disabilities">Disabled people</a></li>
+                    <li><a href="/browse/driving">Driving and transport</a></li>
+                </ul>
+                <ul>
+                    <li><a href="/browse/education">Education and learning</a></li>
+                    <li><a href="/browse/employing-people">Employing people</a></li>
+                    <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
+                    <li><a href="/browse/housing-local-services">Housing and local services</a></li>
+                    <li><a href="/browse/tax">Money and tax</a></li>
+                    <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
+                    <li><a href="/browse/visas-immigration">Visas and immigration</a></li>
+                    <li><a href="/browse/working">Working, jobs and pensions</a></li>
+                </ul>
+            </div>
+
+            <div class="footer-inside-government">
+                <h2>Departments and policy</h2>
+
+                <ul>
+                    <li><a href="/government/how-government-works">How government works</a></li>
+                    <li><a href="/government/organisations">Departments</a></li>
+                    <li><a href="/government/world">Worldwide</a></li>
+                    <li><a href="/government/policies">Policies</a></li>
+                    <li><a href="/government/publications">Publications</a></li>
+                    <li><a href="/government/announcements">Announcements</a></li>
+                </ul>
+            </div>
+            <hr>
+        </div>
+
+
+        <div class="footer-meta">
+            <div class="footer-meta-inner">
+                <h2 class="visuallyhidden">Support links</h2>
+                <ul>
+                    <li><a href="/help">Help</a></li>
+                    <li><a href="/help/cookies">Cookies</a></li>
+                    <li><a href="/contact">Contact</a></li>
+                    <li><a href="/help/terms-conditions">Terms and conditions</a></li>
+                    <li><a href="/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a></li>
+                    <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+                    </li>
+                </ul>
+
+
+
+                <div class="open-government-licence">
+                    <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+                    <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+                </div>
+            </div>
+
+            <div class="copyright">
+                <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+            </div>
+        </div>
+    </div>
+</footer>
+
+<div id="global-app-error" class="app-error hidden"></div>
+
+<script>
+    if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
PLA-1364 - Chunk up the input reference numbers
PLA-1380 - Rename the field "PSA Reference" to something more consistent
PLA-1381 - Pending on protection type, display protected amount appropriately
PLA-1375 - Edit input page to make it clear the tool can be used for all protection types
PLA-1373 - Make the results page state whether a protection is valid or invalid
PLA-1370 - Rename the field "lifetime allowance number" to something more consistent
PLA-1368 - Rename the lookup service to something which means more to users
PLA-1372 - Remove the surplus field labels
PLA-1367 - Convert any lowercase letters to uppercase
PLA-1377 - Edit results page to show the LTA reference
PLA-1383 - Modify the start page